### PR TITLE
Adds in country codes to schema and spec

### DIFF
--- a/src/main/resources/evw/evw-schema.json
+++ b/src/main/resources/evw/evw-schema.json
@@ -68,6 +68,11 @@
           "type": "string",
           "maxLength": 100
         },
+        "countryOfBirthCode": {
+          "id": "countryOfBirthCode",
+          "type": "string",
+          "maxLength": 3
+        },
         "placeOfIssue": {
           "id": "placeOfIssue",
           "type": "string",
@@ -230,6 +235,11 @@
               "maxLength": 100
             },
             {
+              "id": "countryCode",
+              "type": "string",
+              "maxLength": 3
+            },
+            {
               "id": "postcode",
               "type": "string",
               "maxLength": 35
@@ -240,6 +250,11 @@
           "id": "countryAppliedFrom",
           "type": "string",
           "maxLength": 100
+        },
+        "countryAppliedFromCode": {
+          "id": "countryAppliedFromCode",
+          "type": "string",
+          "maxLength": 3
         },
         "phoneNumber": {
           "id": "phoneNumber",
@@ -401,6 +416,11 @@
           "type": "string",
           "maxLength":100
 
+        },
+        "inwardDepartureCountryCode": {
+          "id": "inwardDepartureCountryCode",
+          "type": "string",
+          "maxLength":3
         },
         "inwardDeparturePort": {
           "id": "inwardDeparturePort",

--- a/src/main/resources/evw/evw.json
+++ b/src/main/resources/evw/evw.json
@@ -31,6 +31,7 @@
         "homeAddress3",
         "homeAddress4",
         "Kuwait KWT",
+        "KWT",
         "postcode"
     ],
     "phoneNumber" : "+20 555 3202",
@@ -47,7 +48,13 @@
     "portOfArrival" : "LHR",
     "arrivalDate" : "2015-11-26",
     "arrivalTime" : "21:45",
-    "ukAddress" : ["UkAddress1", "UkAddress2", "UkAddress3", "UkAddress4", "Postcode"],
+    "ukAddress" : [
+        "UkAddress1",
+        "UkAddress2",
+        "UkAddress3",
+        "UkAddress4",
+        "Postcode"
+    ],
     "departureDate": "2015-06-28",
     "ukVisitPhoneNumber": "0793487837429",
     "visitMoreThanOnce": "No",


### PR DESCRIPTION
- `evw-customer` is now passing through codes as well as countries for each country input in the form
- corresponding PR here https://github.com/UKHomeOffice/evw-customer/pull/182